### PR TITLE
PADV-377 - Enable comprehensive theming

### DIFF
--- a/tutorecommerce/templates/ecommerce/build/ecommerce/Dockerfile
+++ b/tutorecommerce/templates/ecommerce/build/ecommerce/Dockerfile
@@ -51,6 +51,8 @@ RUN cd /openedx/requirements/ \
 {% for extra_requirement in ECOMMERCE_EXTRA_PIP_REQUIREMENTS %}RUN pip install {{ extra_requirement }}
 {% endfor %}
 
+{{ patch("ecommerce-dockerfile-theme-extras") }}
+
 # Collect static assets (aka: "make static")
 COPY --chown=app:app assets.py ./ecommerce/settings/assets.py
 ENV DJANGO_SETTINGS_MODULE ecommerce.settings.assets

--- a/tutorecommerce/templates/ecommerce/build/ecommerce/assets.py
+++ b/tutorecommerce/templates/ecommerce/build/ecommerce/assets.py
@@ -7,3 +7,5 @@ for logger in LOGGING["loggers"].values():
 
 COMPRESS_ENABLED = True
 COMPRESS_OFFLINE = True
+
+{{ patch("ecommerce-assets-theme-extras") }}


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-377

## Description

We have decided to continue using the [comprehensive themes developed for ecommerce](https://github.com/Pearson-Advance/openedx-themes/tree/open-release/juniper.master/ecommerce) instead of enabling the [Payment MFE](https://github.com/openedx/frontend-app-payment) however the [ecommerce Tutor Dockerfile](https://github.com/overhangio/tutor-ecommerce/blob/master/tutorecommerce/templates/ecommerce/build/ecommerce/Dockerfile) does not support comprehensive themes feature, therefore we need to support comprehensive theming in the ecommerce Tutor Dockerfile. In contrast to the [edxapp Tutor Dockerfile](https://github.com/overhangio/tutor/blob/master/tutor/templates/build/openedx/Dockerfile) that support different Tutor Patches, which allow to extend the Docker image, the ecommerce Dockerfile does not support extension via Tutor Patches.

Subsequently, this PR adds two new patches that it allows to enable comprehensive theming in tutor.

## Changes Made

- [x] Add new patch in Dockerfile
- [x] Add new patch in assets.py

## How to test

- Install a Tutor with `pip install "tutor[full]"` .
- Clone this plugin with `git clone git@github.com:Pearson-Advance/tutor-ecommerce.git`.
- Install the plugin with `pip install -e ./tutor-ecommerce` or the path where you clone the repository.
- Run: `tutor plugins list` and there should be these plugins `ecommerce`, `discovery` and `mfe`.
- Enable each one of them: `tutor plugins enable ecommerce discovery mfe`.
- Run: `tutor plugins list` and you should see the plugin you selected with the enabled status.
- Run `tutor config save`.
- See the actual settings configured in `code ~/.local/share/tutor`. (you can use VSCode search functionality)

## Reviewers

- [ ] @Squirrel18
- [ ] @anfbermudezme 
- [ ] @alexjmpb 