### PR TITLE
feat: override ECOMMERCE_REPOSITORY.

### DIFF
--- a/tutorecommerce/templates/ecommerce/build/ecommerce/Dockerfile
+++ b/tutorecommerce/templates/ecommerce/build/ecommerce/Dockerfile
@@ -22,8 +22,8 @@ RUN nodeenv /openedx/nodeenv --node=16.14.2 --prebuilt
 ENV PATH /openedx/nodeenv/bin:${PATH}
 
 # Install ecommerce
-ARG ECOMMERCE_REPOSITORY=https://github.com/edx/ecommerce.git
-ARG ECOMMERCE_VERSION={{ OPENEDX_COMMON_VERSION }}
+ARG ECOMMERCE_REPOSITORY={{ ECOMMERCE_REPOSITORY }}
+ARG ECOMMERCE_VERSION={{ ECOMMERCE_VERSION }}
 RUN mkdir -p /openedx/ecommerce && \
     git clone $ECOMMERCE_REPOSITORY --branch $ECOMMERCE_VERSION --depth 1 /openedx/ecommerce
 WORKDIR /openedx/ecommerce


### PR DESCRIPTION
## Description

Even though the default value of each argument can be overridden by using the `--build-arg` flag in the `docker build` command, we are not passing any arguments in our `tutor-build-image-action`. You can see it [here](https://github.com/Pearson-Advance/tutor-build-image-action/blob/45d31df2a2cf6512571679393bf24371e6dce802/action.yml#L196-L202). However, this PR proposes to edit the Dockerfile in order to override the ARGs mentioned below:

```
ARG ECOMMERCE_REPOSITORY=https://github.com/edx/ecommerce.git
ARG ECOMMERCE_VERSION={{ OPENEDX_COMMON_VERSION }}
```

We aim to stick to the idea of having a single source of truth and avoid adding these variables as inputs or environment variables in the GitHub Actions workflow. Instead, we will use the variables defined by our `tutor-pearson-plugin`, which you can find [here](https://github.com/Pearson-Advance/tutor-pearson-plugin/blob/5cc8f49592859d26d11cb00c816a0a43f8baab0b/tutor_pearson_plugin/services/ecommerce/defaults.py#L9-L10).

