### PR TITLE
feat: use ECOMMERCE_GIT_VERSION to define ECOMMERCE_VERSION in DockerFile.

### DIFF
--- a/tutorecommerce/templates/ecommerce/build/ecommerce/Dockerfile
+++ b/tutorecommerce/templates/ecommerce/build/ecommerce/Dockerfile
@@ -23,7 +23,7 @@ ENV PATH /openedx/nodeenv/bin:${PATH}
 
 # Install ecommerce
 ARG ECOMMERCE_REPOSITORY={{ ECOMMERCE_REPOSITORY }}
-ARG ECOMMERCE_VERSION={{ ECOMMERCE_VERSION }}
+ARG ECOMMERCE_VERSION={{ ECOMMERCE_GIT_VERSION }}
 RUN mkdir -p /openedx/ecommerce && \
     git clone $ECOMMERCE_REPOSITORY --branch $ECOMMERCE_VERSION --depth 1 /openedx/ecommerce
 WORKDIR /openedx/ecommerce


### PR DESCRIPTION
## Description.
In order to avoid conflicts with the `ECOMMERCE_VERSION` variable [here](https://github.com/Pearson-Advance/tutor-ecommerce/blob/b4f35721cb1adbb828536d466dbc07a1f7e86a40/tutorecommerce/plugin.py#L44), We decided to use another variable to define the branch of our repository.