### PR TITLE
feat: remove unused MFEs.

### DIFF
--- a/tutorecommerce/plugin.py
+++ b/tutorecommerce/plugin.py
@@ -65,27 +65,6 @@ config = {
 }
 
 
-@MFE_APPS.add()  # type: ignore
-def _add_ecommerce_mfe_apps(
-    apps: dict[str, MFE_ATTRS_TYPE]
-) -> dict[str, MFE_ATTRS_TYPE]:
-    apps.update(
-        {
-            "orders": {
-                "repository": "https://github.com/openedx/frontend-app-ecommerce.git",
-                "version": "open-release/sumac.master",
-                "port": 7296,
-            },
-            "payment": {
-                "repository": "https://github.com/openedx/frontend-app-payment.git",
-                "version": "open-release/sumac.master",
-                "port": 1998,
-            },
-        }
-    )
-    return apps
-
-
 # Initialization hooks
 for service in ("mysql", "lms", "ecommerce"):
     with open(


### PR DESCRIPTION
## Description

This change removes unused Micro-Frontends (MFEs) related to the ecommerce plugin from the tutorecommerce/plugin.py configuration. These MFEs are no longer required, and eliminating them simplifies the plugin code and reduces unnecessary dependencies.

## Changes made

- [x] Deleted the @MFE_APPS.add() decorated function that previously registered ecommerce-related MFEs (orders, payment).
- [x] Removed the associated code that updated the MFE apps dictionary with those entries.
- [x] No functional replacements for the removed MFEs are included in this commit.

## Reviewers

- [x] @AuraAlba